### PR TITLE
Fix for 2010L and up on Wine

### DIFF
--- a/Novetus/NovetusCore/StorageAndFunctions/GlobalFuncs.cs
+++ b/Novetus/NovetusCore/StorageAndFunctions/GlobalFuncs.cs
@@ -2154,6 +2154,7 @@ public class GlobalFuncs
     {
         Process client = new Process();
         client.StartInfo.FileName = rbxexe;
+	client.StartInfo.WorkingDirectory = Path.GetDirectoryName(rbxexe);
         client.StartInfo.Arguments = args;
         if (e != null)
         {


### PR DESCRIPTION
Clients now correctly start in the executable directory. Not fully tested